### PR TITLE
Feature update docker with env setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,19 @@
     FROM node:18 AS frontend-service
 
     RUN corepack enable
-
-
+    
     WORKDIR /client
-        
+    
     COPY client/package.json client/pnpm-lock.yaml ./
+    
+    ARG NEXT_PUBLIC_API_BASE_URL
+    ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
     
     RUN pnpm install --frozen-lockfile
     
     COPY client/ .
-        
-# ---------- BACKEND SERVICE ----------
+    
+    # ---------- BACKEND SERVICE ----------
     FROM python:3.12 AS backend-service
     
     WORKDIR /server
@@ -24,3 +26,4 @@
     RUN pipenv install --system --deploy
     
     COPY server/ .
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,44 @@
-services:  
+
+version: '3.8'
+
+services:
   client:
     build:
       context: .
       target: frontend-service
+      args:
+        NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     volumes:
       - ./client:/client
+    environment:
+      - NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
     command: ["pnpm", "run", "dev"]
-  
+    depends_on:
+      - server
+
   server:
     build:
-      context: . 
-      target: backend-service 
+      context: .
+      target: backend-service
     ports:
       - "${BACKEND_PORT:-8000}:8000"
     volumes:
       - ./server:/server
     environment:
-      - MONGO_URI=${MONGO_URI} 
+      - MONGO_URI=${MONGO_URI}
       - PYTHONPATH=/
+      - ALLOWED_ORIGINS=http://localhost:3000
     command: ["uvicorn", "server.main:app", "--host", "0.0.0.0", "--port", "${BACKEND_PORT:-8000}", "--reload"]
     depends_on:
       - mongodb
-  
-  mongodb:  
-    image: mongo:latest    
-    ports:  
-      - "${MONGO_PORT:-27017}:27017"   
-    volumes:  
+
+  mongodb:
+    image: mongo:latest
+    ports:
+      - "${MONGO_PORT:-27017}:27017"
+    volumes:
       - mongo_data:/data/db
 
   seed:
@@ -44,5 +54,6 @@ services:
       - server
       - mongodb
 
-volumes:  
+volumes:
   mongo_data:
+

--- a/package.json
+++ b/package.json
@@ -30,5 +30,6 @@
       "eslint --fix",
       "git add"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }


### PR DESCRIPTION
## This Feature Updates The Docker Set Up With The Environment Variables Recently Introduced In The Quiz App.

* ALLOWED_ORIGINS
* NEXT_PUBLIC_API_BASE_URL

How to Test:

* Switch to the feature branch
* Ensure in your server .env file you have these configured

```
MONGO_URI=mongodb://mongodb:27017/quizApp_db
ALLOWED_ORIGINS=http://localhost:3000
```

Then in the client/.env.local file ensure you have these configured

```
NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
```

* start up Docker in the terminal with the command:

```bash
docker compose up  --build
```
* Navigate to http://localhost:3000 in your browser; the app should be live and running fully on Docker.